### PR TITLE
Chancellor scoring

### DIFF
--- a/core/src/io/github/teamfractal/actors/GameScreenActors.java
+++ b/core/src/io/github/teamfractal/actors/GameScreenActors.java
@@ -339,7 +339,7 @@ public class GameScreenActors {
     {
         chancellorCaughtLabel.setVisible(true);
         if(caught) {
-            chancellorCaughtLabel.setText("YOU CAUGHT THE CHANCELLOR\nYou have now caught " + game.getPlayer().chancellorsCaught() + " Chancellor" + (game.getPlayer().chancellorsCaught() == 1 ? "" : "s"));
+            chancellorCaughtLabel.setText("YOU CAUGHT THE CHANCELLOR\nYou have now caught " + game.getPlayer().getChancellorsCaught() + " Chancellor" + (game.getPlayer().getChancellorsCaught() == 1 ? "" : "s"));
         }
         else {
             chancellorCaughtLabel.setText("The Chancellor got away\nBetter luck next time!");

--- a/core/src/io/github/teamfractal/entity/Player.java
+++ b/core/src/io/github/teamfractal/entity/Player.java
@@ -20,7 +20,6 @@ import io.github.teamfractal.exception.*;
 import java.util.ArrayList;
 import java.util.Random;
 
-
 public class Player {
     public RoboticonQuest game;
     Array<Roboticon> roboticonList;
@@ -30,6 +29,8 @@ public class Player {
     private int energy = 0;
     private int food = 0;
     private int chancellorsCaught = 0;
+
+    private static final int CHANELLOR_SCORE_WEIGHT = 20;
 
     public Player(RoboticonQuest game){
         this.game = game;
@@ -377,7 +378,7 @@ public class Player {
      * @return The score of the player.
      */
     public int calculateScore(){
-        return ore + energy + food;
+        return ore + energy + food + (CHANELLOR_SCORE_WEIGHT * chancellorsCaught);
     }
 
     /**
@@ -398,5 +399,5 @@ public class Player {
     }
 
     //Added by JBT
-    public int chancellorsCaught() {return chancellorsCaught;}
+    public int getChancellorsCaught() {return chancellorsCaught;}
 }

--- a/core/src/io/github/teamfractal/entity/Player.java
+++ b/core/src/io/github/teamfractal/entity/Player.java
@@ -8,6 +8,7 @@
  *      Deleted unused and untested methods
  *      Removed un-needed synchronization
  *      Added a variable for the amount of chancellors caught
+ *      Added weighting for the amount of caught chancellors
  */
 
 package io.github.teamfractal.entity;
@@ -30,7 +31,7 @@ public class Player {
     private int food = 0;
     private int chancellorsCaught = 0;
 
-    private static final int CHANELLOR_SCORE_WEIGHT = 20;
+    public static final int CHANELLOR_SCORE_WEIGHT = 20;
 
     public Player(RoboticonQuest game){
         this.game = game;
@@ -400,4 +401,7 @@ public class Player {
 
     //Added by JBT
     public int getChancellorsCaught() {return chancellorsCaught;}
+
+    //Added by JBT for testing purposes
+    public void setChancellorsCaught(int value) { chancellorsCaught = value;}
 }

--- a/test/src/io/github/teamfractal/entity/PlayerTest.java
+++ b/test/src/io/github/teamfractal/entity/PlayerTest.java
@@ -480,7 +480,7 @@ public class PlayerTest extends TesterFile {
         player.setChancellorsCaught(2);
 
         //Check that the players score is 6
-        assertEquals(46, player.calculateScore());
+        assertEquals(6 + (player.CHANELLOR_SCORE_WEIGHT * player.getChancellorsCaught()), player.calculateScore());
     }
 
     //Test created by JBT

--- a/test/src/io/github/teamfractal/entity/PlayerTest.java
+++ b/test/src/io/github/teamfractal/entity/PlayerTest.java
@@ -468,6 +468,23 @@ public class PlayerTest extends TesterFile {
 
     //Test created by JBT
     /**
+     * Tests that the correct score is calculated for a player when calculateScore is called
+     */
+    @Test
+    public void getScoreWithChancellor()
+    {
+        //Set the players resources to equal 6 in total
+        player.setResource(ResourceType.ORE, 2);
+        player.setResource(ResourceType.ENERGY, 1);
+        player.setResource(ResourceType.FOOD, 3);
+        player.setChancellorsCaught(2);
+
+        //Check that the players score is 6
+        assertEquals(46, player.calculateScore());
+    }
+
+    //Test created by JBT
+    /**
      * Tests that the getRoboticonQuantities function returns the correct data for owned roboticons
      */
     @Test


### PR DESCRIPTION
Not much to say, added chancellor scoring support.
Score per chancellor is defined as a constant in player, at the moment it is 20, but can be changed without breaking the new testing.

Speaking of, added another test for chancellor score support!